### PR TITLE
Adding html reporters for jest and postman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,14 @@ RUN apt update && \
     apt install -y curl && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt install -y nodejs && \
-    apt clean && rm -rf /var/lib/apt/lists/*
+    apt clean
+
+# Install htmlextra reporter globally
+RUN npm install -g newman-reporter-htmlextra jest-html-reporter
+
+# Set NODE_PATH to ensure global modules are accessible
+ENV NODE_PATH=/usr/lib/node_modules
+# ENV PATH=$PATH:/usr/lib/node_modules/.bin
 
 # Create app directory
 WORKDIR /app

--- a/jest-testing.sh
+++ b/jest-testing.sh
@@ -1,0 +1,2 @@
+export JEST_HTML_REPORTER_OUTPUT_PATH=./jest-reports/jest.html
+export JEST_HTML_REPORTER_PAGE_TITLE="Test\ Report"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "postman": "newman run tests/postman/collection.json"
+    "test-report": "npm test -- --reporters=default --reporters=jest-html-reporter",
+    "postman": "newman run tests/postman/collection.json",
+    "postman-report": "newman run tests/postman/collection.json -r cli,htmlextra --reporter-htmlextra-export newman/POSTMAN-html-report.html"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "test-report": "source ./jest-testing.sh && jest --reporters=default --reporters=jest-html-reporter"
+    "test-report": "source ./jest-testing.sh && jest --reporters=default --reporters=jest-html-reporter",
     "postman": "newman run tests/postman/collection.json",
     "postman-report": "newman run tests/postman/collection.json -r cli,htmlextra --reporter-htmlextra-export newman/POSTMAN-html-report.html"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "test-report": "npm test -- --reporters=default --reporters=jest-html-reporter",
+    "test-report": "source ./jest-testing.sh && jest --reporters=default --reporters=jest-html-reporter"
     "postman": "newman run tests/postman/collection.json",
     "postman-report": "newman run tests/postman/collection.json -r cli,htmlextra --reporter-htmlextra-export newman/POSTMAN-html-report.html"
   },


### PR DESCRIPTION
## CHANGELOG
- [x] Add html reporters for jest
- [x] Add html reporters forpostman
- [x] Reporters should be configured via cli options


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced testing reporting with user-friendly HTML outputs for both unit and API tests.
  - Added new scripts for generating Jest and Newman reports.

- **Chores**
  - Updated configuration to streamline dependency installation and environment settings for improved module accessibility and report generation.
  - Added environment variables to configure Jest report output settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->